### PR TITLE
Account for changed structure of params

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -245,7 +245,7 @@ class Plugin extends AbstractPlugin
 
         $connectionMask = $this->getConnectionMask($event->getConnection());
         $params = $event->getParams();
-        $channel = ltrim(array_shift($params), '=*@');
+        $channel = $params[1];
         $validPrefixes = implode('', array_keys($this->prefixes));
         $pattern = '/^([' . preg_quote($validPrefixes) . ']+)(.+)$/';
         $logger->debug('Gathering initial user mode data', array(
@@ -253,7 +253,7 @@ class Plugin extends AbstractPlugin
             'channel' => $channel,
         ));
 
-        foreach ($params as $fullNick) {
+        foreach ($params['iterable'] as $fullNick) {
             if (!preg_match($pattern, $fullNick, $match)) {
                 continue;
             }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -295,14 +295,19 @@ class PluginTest extends \PHPUnit_Framework_TestCase
     {
         $channel = '#channel';
         $params = array(
-            $channelPrefix . $channel,
-            '~owner',
-            '&admin',
-            '@op',
-            '%halfop',
-            '+voice',
-            '&@multi',
-            'regular',
+            $channelPrefix,
+            $channel,
+            '~owner &admin @op %halfop +voice &@multi regular',
+            'iterable' => array(
+                '~owner',
+                '&admin',
+                '@op',
+                '%halfop',
+                '+voice',
+                '&@multi',
+                'regular',
+            ),
+            'tail' => '~owner &admin @op %halfop +voice &@multi regular',
         );
         $event = $this->getMockEvent();
         $connection = $this->getMockConnection();
@@ -327,8 +332,13 @@ class PluginTest extends \PHPUnit_Framework_TestCase
     {
         $channel = '#channel';
         $params = array(
-            '=' . $channel,
+            '=',
+            $channel,
             '$unsupported',
+            'iterable' => array(
+                '$unsupported',
+            ),
+            'tail' => '$unsupported',
         );
         $event = $this->getMockEvent();
         $connection = $this->getMockConnection();
@@ -347,8 +357,13 @@ class PluginTest extends \PHPUnit_Framework_TestCase
     {
         $channel = '#channel';
         $params = array(
-            '=' . $channel,
+            '=',
+            $channel,
             '$unsupported',
+            'iterable' => array(
+                '$unsupported',
+            ),
+            'tail' => '$unsupported',
         );
         $event = $this->getMockEvent();
         $connection = $this->getMockConnection();


### PR DESCRIPTION
I've been using phergie/phergie-freenode and noticed a PHP warning in the logs:

> [27-Feb-2016 03:56:07 America/New_York] PHP Warning:  preg_match() expects parameter 2 to be string, array given in /.../vendor/phergie/phergie-irc-plugin-react-usermode/src/Plugin.php on line 257

After digging a bit I realized that Plugin::loadUserModes() probably hasn't worked at all for awhile. Plugin::loadUserModes() handles event `irc.received.rpl_namreply`. I've duplicated the params structure in the tests based on var_debug() from a running instance and corrected the function so the tests pass:

```
array(5) {
  [1] =>
  string(1) "="
  [2] =>
  string(17) "##phergie-testing"
  [3] =>
  string(30) "Alt-Phergie @ChanServ sitedyno"
  'iterable' =>
  array(2) {
    [0] =>
    string(1) "="
    [1] =>
    string(17) "##phergie-testing"
  }
  'tail' =>
  string(30) "Alt-Phergie @ChanServ sitedyno"
}
```

The plugin is correctly handling user mode changes as I can see those changes noted in the debug output.
